### PR TITLE
memoize schema building

### DIFF
--- a/projects/graphql/eslint-plugin-graphql/lib/memoized-build-schema.js
+++ b/projects/graphql/eslint-plugin-graphql/lib/memoized-build-schema.js
@@ -25,7 +25,7 @@ let CACHE = Object.create(null);
  * Cache lifetime:
  *
  * By default the cache will survive for the duration of the process, given
- * that projects have relatively few schema's this should be fine.
+ * that projects have relatively few schemas this should be fine.
  *
  * Although unlikely, if issues arise there is an API to purge the cache in
  * question. NOTE: using this function is not expected behavior, if you are

--- a/projects/graphql/eslint-plugin-graphql/lib/memoized-build-schema.js
+++ b/projects/graphql/eslint-plugin-graphql/lib/memoized-build-schema.js
@@ -1,0 +1,73 @@
+'use strict';
+const { buildSchema } = require('graphql');
+const crypto = require('crypto');
+const debug = require('debug')('eslint-plugin-graphql:cached-build-schema');
+let CACHE = Object.create(null);
+/*
+ * When profiling larg real-world schema's we noticed that a 500kb schema we noticed:
+ *
+ * fs.readFileSync was: < 1ms
+ * warm graphql.parse was: ~10ms
+ * warm graphql.buildSchema was: ~180ms
+ *
+ * So to address this, it was decided to memoize schema construction. Auditing
+ * relevant code suggests this is safe, and will save upwards of 200ms per
+ * graphql file linted, when dealing with a schema of ~500kb.
+ *
+ * Cache key generation:
+ * Since reading the file costs < 1 ms, and md5 hex of full 500kb schema only
+ * takes < ~0.5ms. We would error on the side of safety and always read and
+ * compute the key from the complete schema. Given that file reading and key
+ * generation appears to consume less then 1% of the uncached time, this
+ * memoization safes us nearly ~180ms per linted file on a modern MBP, with a
+ * schema of 500kb
+ *
+ * Cache lifetime:
+ *
+ * By default the cache will survive for the duration of the process, given
+ * that projects have relatively few schema's this should be fine.
+ *
+ * Although unlikely, if issues arise there is an API to purge the cache in
+ * question. NOTE: using this function is not expected behavior, if you are
+ * using this please let us know, as it could be a sign of an underlying issue.
+ *
+ *
+ * ```js
+ * require('eslint-plugin-graphql/lib/memoized-build-schema').clear();
+ * ```
+ *
+ *
+ * Note: This memoization is expected to primarily be of benefit when:
+ * * linting many graphql files in one session
+ * * a persistent linting solution
+ */
+module.exports = function memoizedBuildSchema(schemaString) {
+  debug('key:start');
+  const key = crypto.createHash('md5').update(schemaString).digest('hex');
+  debug('key:end');
+
+  const value = CACHE[key];
+
+  if (value === undefined) {
+    // miss
+    debug('miss');
+    debug('build-schema:start');
+    CACHE[key] = buildSchema(schemaString);
+    debug('build-schema:end');
+    return CACHE[key];
+  } else {
+    debug('hit');
+    // hit
+    return value;
+  }
+};
+
+/*
+ *
+ * Although unlikely, if issues arise there is an API to purge the cache in
+ * question. NOTE: using this function is not expected behavior, if you are
+ * using this please let us know, as it could be a sign of an underlying issue.
+ */
+module.exports.clear = function () {
+  CACHE = Object.create(null);
+};

--- a/projects/graphql/eslint-plugin-graphql/lib/memoized-build-schema.js
+++ b/projects/graphql/eslint-plugin-graphql/lib/memoized-build-schema.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const debug = require('debug')('eslint-plugin-graphql:cached-build-schema');
 let CACHE = Object.create(null);
 /*
- * When profiling larg real-world schema's we noticed that a 500kb schema we noticed:
+ * When profiling large real-world schemas we noticed that for a particular 500kb schema:
  *
  * fs.readFileSync was: < 1ms
  * warm graphql.parse was: ~10ms

--- a/projects/graphql/eslint-plugin-graphql/package.json
+++ b/projects/graphql/eslint-plugin-graphql/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "debug": "^4.2.0",
     "graphql": "^15.3.0",
     "mocha": "^8.1.0",
     "resolve": "^1.17.0"

--- a/projects/graphql/eslint-plugin-graphql/tests/memoized-build-schema-test.js
+++ b/projects/graphql/eslint-plugin-graphql/tests/memoized-build-schema-test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const memoizedBuildSchema = require('../lib/memoized-build-schema');
+const { expect } = require('chai');
+
+describe('memoized-build-schema', function () {
+  it('identity of schema is based on content of the schemaString', function () {
+    const schema1 = memoizedBuildSchema(`
+type Apple {
+  id: String!
+}`);
+
+    const schema2 = memoizedBuildSchema(`
+type Apple {
+  id: String!
+}`);
+
+    const schema3 = memoizedBuildSchema(`
+# comment
+type Apple {
+  id: String!
+}`);
+
+    expect(schema1).to.equal(schema2);
+    expect(schema1).to.not.equal(schema3);
+    expect(schema2).to.not.equal(schema3);
+  });
+  it('has a clearable cache', function () {
+    const SCHEMA = `
+type Apple {
+  id: String!
+}`;
+    const schema1 = memoizedBuildSchema(SCHEMA);
+    const schema2 = memoizedBuildSchema(SCHEMA);
+
+    memoizedBuildSchema.clear();
+
+    const schema3 = memoizedBuildSchema(SCHEMA);
+    const schema4 = memoizedBuildSchema(SCHEMA);
+
+    expect(schema1).to.equal(schema2);
+    expect(schema3).to.equal(schema4);
+    expect(schema1).to.not.equal(schema3);
+    expect(schema1).to.not.equal(schema4);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,22 +23,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@eslint/eslintrc@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
-  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
-  dependencies:
-    ajv "^6.12.4"
-    debug "^4.1.1"
-    espree "^7.3.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.2.1"
-    js-yaml "^3.13.1"
-    lodash "^4.17.19"
-    minimatch "^3.0.4"
-    strip-json-comments "^3.1.1"
-
 "@iarna/toml@2.2.5":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
@@ -263,7 +247,7 @@ acorn-jsx@^5.2.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
-acorn@^7.3.1, acorn@^7.4.0:
+acorn@^7.3.1:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
   integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
@@ -301,16 +285,6 @@ ajv@^6.10.0, ajv@^6.10.2:
   version "6.12.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
   integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.12.4:
-  version "6.12.5"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
-  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -810,12 +784,19 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@4.1.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@4.1.1, debug@^4.0.1, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1183,64 +1164,12 @@ eslint@^7.5.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^7.9.0:
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.9.0.tgz#522aeccc5c3a19017cf0cb46ebfd660a79acf337"
-  integrity sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.1.3"
-    ajv "^6.10.0"
-    chalk "^4.0.0"
-    cross-spawn "^7.0.2"
-    debug "^4.0.1"
-    doctrine "^3.0.0"
-    enquirer "^2.3.5"
-    eslint-scope "^5.1.0"
-    eslint-utils "^2.1.0"
-    eslint-visitor-keys "^1.3.0"
-    espree "^7.3.0"
-    esquery "^1.2.0"
-    esutils "^2.0.2"
-    file-entry-cache "^5.0.1"
-    functional-red-black-tree "^1.0.1"
-    glob-parent "^5.0.0"
-    globals "^12.1.0"
-    ignore "^4.0.6"
-    import-fresh "^3.0.0"
-    imurmurhash "^0.1.4"
-    is-glob "^4.0.0"
-    js-yaml "^3.13.1"
-    json-stable-stringify-without-jsonify "^1.0.1"
-    levn "^0.4.1"
-    lodash "^4.17.19"
-    minimatch "^3.0.4"
-    natural-compare "^1.4.0"
-    optionator "^0.9.1"
-    progress "^2.0.0"
-    regexpp "^3.1.0"
-    semver "^7.2.1"
-    strip-ansi "^6.0.0"
-    strip-json-comments "^3.1.0"
-    table "^5.2.3"
-    text-table "^0.2.0"
-    v8-compile-cache "^2.0.3"
-
 espree@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-7.2.0.tgz#1c263d5b513dbad0ac30c4991b93ac354e948d69"
   integrity sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
   dependencies:
     acorn "^7.3.1"
-    acorn-jsx "^5.2.0"
-    eslint-visitor-keys "^1.3.0"
-
-espree@^7.3.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
-  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
-  dependencies:
-    acorn "^7.4.0"
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.3.0"
 
@@ -1744,7 +1673,7 @@ import-cwd@3.0.0:
   dependencies:
     import-from "^3.0.0"
 
-import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
@@ -3287,7 +3216,7 @@ strip-json-comments@3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+strip-json-comments@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==


### PR DESCRIPTION
- memoize schema construction 
  - 180ms savings (on my laptop) per schema construction once that schema has been constructed once.
- add some `debug` logging, to help future debugging