### PR TITLE
Fix typeInfo ordering

### DIFF
--- a/projects/graphql/eslint-plugin-graphql/lib/graphql-rule-adapter.js
+++ b/projects/graphql/eslint-plugin-graphql/lib/graphql-rule-adapter.js
@@ -60,28 +60,62 @@ module.exports = function adapt(rule) {
           });
         },
       );
-      const rules = rule(validationContext);
+      // This is a GraphQL Visitor, which is either EnterLeave or a ShapeMap
+      // see https://github.com/graphql/graphql-js/blob/bbd8429b85594d9ee8cc632436e2d0f900d703ef/src/language/visitor.js#L11
+      const ruleVisitor = rule(validationContext);
 
       const callbacks = { enter() {}, leave() {} };
 
       wrappedRules['*'] = function (node) {
         typeInfo.enter(context.parserServices.correspondingNode(node));
+        // here we call the enter/leave visitor AND the shape visitor
+        // but they are mutually exclusive
+        // see impl https://github.com/graphql/graphql-js/blob/3aad20bf1cccda59ccb8d855584097fcf7348fef/src/language/visitor.js#L404-L436
         callbacks.enter(node);
+        if (node.type in ruleVisitor) {
+          let visitNode = ruleVisitor[node.type];
+          if ('enter' in visitNode && typeof visitNode.enter === 'function') {
+            return visitNode.enter(
+              /* node       */ context.parserServices.correspondingNode(node),
+              /* TODO: key (Not currently used by validations)  */ undefined,
+              /* parent     */ context.parserServices.correspondingNode(node.parent),
+              /* TODO: path (Not currently used by validations) */ undefined,
+              /* ancestors  */ ancestors(node).map(ancestor =>
+                context.parserServices.correspondingNode(ancestor),
+              ),
+            );
+          }
+        }
       };
 
       wrappedRules['*:exit'] = function (node) {
-        typeInfo.leave(context.parserServices.correspondingNode(node));
+        if (node.type in ruleVisitor) {
+          let visitNode = ruleVisitor[node.type];
+          if ('leave' in visitNode && typeof visitNode.leave === 'function') {
+            return visitNode.leave(
+              /* node       */ context.parserServices.correspondingNode(node),
+              /* TODO: key (Not currently used by validations)  */ undefined,
+              /* parent     */ context.parserServices.correspondingNode(node.parent),
+              /* TODO: path (Not currently used by validations) */ undefined,
+              /* ancestors  */ ancestors(node).map(ancestor =>
+                context.parserServices.correspondingNode(ancestor),
+              ),
+            );
+          }
+        }
         callbacks.leave(node);
+        typeInfo.leave(context.parserServices.correspondingNode(node));
       };
 
-      for (const ruleName in rules) {
-        const rule = rules[ruleName];
-        const type = typeof rule;
+      for (const visitorNodeName in ruleVisitor) {
+        const visitorNode = ruleVisitor[visitorNodeName];
+
+        const type = typeof visitorNode;
         if (type === 'function') {
           // eslint visitor
           const callback = function (node) {
             // graphql visitor
-            return rules[ruleName](
+            return ruleVisitor[visitorNodeName](
               /* node        */ context.parserServices.correspondingNode(node),
               /* TODO: key (Not currently used by validations) */ undefined,
               /* parent      */ context.parserServices.correspondingNode(node.parent),
@@ -93,54 +127,50 @@ module.exports = function adapt(rule) {
           };
 
           // this handles the scenario with visitor.enter
-          if (ruleName === 'enter') {
+          if (visitorNodeName === 'enter') {
+            // {
+            //  enter() {}
+            // }
+            //
             callbacks.enter = callback;
-          } else if (ruleName === 'leave') {
+          } else if (visitorNodeName === 'leave') {
+            // {
+            //  leave() {}
+            // }
+            //
             callbacks.leave = callback;
           } else {
-            wrappedRules[ruleName] = callback;
-          }
-        } else if (type === 'object' && rule !== null) {
-          let hadVisitor = false;
-          // bridge graphql document.leave with eslint's document:leave selector
-          if (typeof rule.enter === 'function') {
-            hadVisitor = true;
-            // eslint visitor
-            wrappedRules[ruleName] = function (node) {
-              // graphql visitor
-              return rule.enter(
-                /* node       */ context.parserServices.correspondingNode(node),
-                /* TODO: key (Not currently used by validations)  */ undefined,
-                /* parent     */ context.parserServices.correspondingNode(node.parent),
-                /* TODO: path (Not currently used by validations) */ undefined,
-                /* ancestors  */ ancestors(node).map(ancestor =>
-                  context.parserServices.correspondingNode(ancestor),
-                ),
-              );
-            };
-          }
-
-          if (typeof rule.leave === 'function') {
-            hadVisitor = true;
-            // eslint visitor
-            wrappedRules[ruleName + ':exit'] = function (node) {
-              // graphql visitor
-              return rule.leave(
-                /* node       */ context.parserServices.correspondingNode(node),
-                /* TODO: key (Not currently used by validations) */ undefined,
-                /* parent     */ context.parserServices.correspondingNode(node.parent),
-                /* TODO: path (Not currently used by validations) */ undefined,
-                /* ancestors  */ ancestors(node).map(ancestor =>
-                  context.parserServices.correspondingNode(ancestor),
-                ),
-              );
-            };
-          }
-
-          if (!hadVisitor) {
-            throw new Error(`Unsupported rule member: ${Object.keys(rule)}`);
+            // {
+            //  Field() {}
+            // }
+            //
+            // In this case we'll add an ESLint visitor for the specific node.
+            // The typeInfo would be out of order on leave, but the node
+            // doens't have a leave hook in this format as it's
+            //
+            // {
+            //  Field() {}
+            // }
+            //
+            // as opposed to
+            //
+            // {
+            //  Field {
+            //    enter() {}
+            //    leave() {}
+            //  }
+            // }
+            //
+            wrappedRules[visitorNodeName] = callback;
           }
         } else {
+          if (
+            type === 'object' &&
+            visitorNode !== null &&
+            ('enter' in visitorNode || 'leave' in visitorNode)
+          ) {
+            continue;
+          }
           throw new Error(`Unknown rule type: '${type}'`);
         }
       }

--- a/projects/graphql/eslint-plugin-graphql/tests/rules/graphql-validation-rules-test.js
+++ b/projects/graphql/eslint-plugin-graphql/tests/rules/graphql-validation-rules-test.js
@@ -747,7 +747,11 @@ tester.run('ProvidedRequiredArgumentsRule', plugin.rules.ProvidedRequiredArgumen
     {
       code: `
 {
-  dog @skip(if: true)
+  cat {
+    affection(bittenRecently: false) {
+      value
+    }
+  }
 }`,
     },
   ],

--- a/projects/graphql/eslint-plugin-graphql/tests/rules/schema.graphql
+++ b/projects/graphql/eslint-plugin-graphql/tests/rules/schema.graphql
@@ -13,6 +13,7 @@ interface Mammal {
 }
 interface Pet implements Being {
   name(surname: Boolean): String
+  affection(bittenRecently: Boolean!): PetAffection
 }
 interface Canine implements Mammal & Being {
   name(surname: Boolean): String
@@ -24,8 +25,13 @@ enum DogCommand {
   HEEL
   DOWN
 }
+type PetAffection {
+  value: Int
+}
+
 type Dog implements Being & Pet & Mammal & Canine {
   name(surname: Boolean): String
+  affection(bittenRecently: Boolean!): PetAffection
   nickname: String
   barkVolume: Int
   barks: Boolean
@@ -37,6 +43,7 @@ type Dog implements Being & Pet & Mammal & Canine {
 }
 type Cat implements Being & Pet {
   name(surname: Boolean): String
+  affection(bittenRecently: Boolean!): PetAffection
   nickname: String
   meows: Boolean
   meowsVolume: Int


### PR DESCRIPTION
Unfortunately with the following visitor

```
{
  '*'()           { console.log('*:enter') },
  '*:exit'()      { console.log('*:exit') },
  'Field'()       { console.log('Field:enter') },
  'Field:exit'()  { console.log('Field:exit') },
}
```

Eslint gets us

```
*:enter
Field:enter
*:leave
Field:leave
```

Instead of the more sensible

```
*:enter
Field:enter
Field:leave
*:leave
```

This means that neither the general node nor specific node can be relied
on to bracket the other kind: they will be out of order either on the
way down the tree or on the way back up.

However, GraphQL's `TypeInfo` expects to enter before its rules enter
and to leave before its rules leave.  Because of our failure to bracket
the rule visitor correctly due to ESLint's odd traversal, type checking
would have the wrong field types in certain cases, as with the
following:

```
{
  cat {
    affection(bittenRecently: false) {
      value
    }
  }
}
```

When leaving the `value` field, if we leave the typeInfo first, `value`
will be out of step with the field definition stack and think that it
needs to check `bittenRecently` as a required parameter.

This commit fixes the traversal issue by executing everything within the
generic `*` nodes in the ESLint visitor so that typeInfo can bracket the
rule visit.