### PR TITLE
fix(parser): pathOf handle fragments with no condition

### DIFF
--- a/projects/graphql/eslint-plugin-graphql/parser.js
+++ b/projects/graphql/eslint-plugin-graphql/parser.js
@@ -91,7 +91,11 @@ module.exports.parseForESLint = function (code, options = {}) {
               parts.unshift(node.operation);
               break;
             case 'InlineFragment':
-              parts.unshift(`... on ${node.typeCondition.name.value}`);
+              if (node.typeCondition) {
+                parts.unshift(`... on ${node.typeCondition.name.value}`);
+              } else {
+                parts.unshift(`...`);
+              }
               break;
             case 'ObjectTypeDefinition':
             case 'InterfaceTypeDefinition':


### PR DESCRIPTION
Fix for the issue reported in https://github.com/stefanpenner/eslint-ast/issues/18 . Adding condition that checks if `typeCondition` exists and handles the case when there is none