### PR TITLE
Add getGraphQL to parser services

### DIFF
--- a/projects/graphql/eslint-plugin-graphql/parser.js
+++ b/projects/graphql/eslint-plugin-graphql/parser.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 
+const graphql = require('graphql');
 const { parse, visit, TypeInfo } = require('graphql');
 const visitorKeys = require('graphql/language/visitor').QueryDocumentKeys;
 
@@ -70,6 +71,15 @@ module.exports.parseForESLint = function (code, options = {}) {
       },
       getDocument() {
         return this.correspondingNode(ast);
+      },
+
+      /**
+       * This exists for rules to get the same version of the graphql library
+       * used so that `Duplicate "graphql" modules cannot be used at the ...`
+       * error can be avoided
+       */
+      getGraphQL() {
+        return graphql;
       },
 
       createTypeInfo() {

--- a/projects/graphql/eslint-plugin-graphql/tests/parser-test.js
+++ b/projects/graphql/eslint-plugin-graphql/tests/parser-test.js
@@ -242,4 +242,19 @@ query {
     const path = result.services.pathOf(inlineFragmentNode);
     expect(path).to.be.equal('query/nested/... on Something');
   });
+
+  it('has a functioning getGraphQL that returns graphql lib', function () {
+    const result = parser.parseForESLint(
+      `
+query {
+  id
+}`,
+      {
+        schema,
+      },
+    );
+
+    const graphqlLib = result.services.getGraphQL();
+    expect(graphqlLib.isListType).to.be.equal(require('graphql').isListType);
+  });
 });


### PR DESCRIPTION
Add `parserServices.getGraphQL()`.

Lint rules will sometimes want type information (via `parserServices.createTypeInfo()`), but this relies on having exactly the same instance of the graphql library since `graphql` does testing via `instanceof`.

For this reason, we expose the same instance of `graphql` used by the type info. Users should use this rather than manually `require`ing graphql.